### PR TITLE
Fixed image link

### DIFF
--- a/data-collection/qualitative-methods/observations.qmd
+++ b/data-collection/qualitative-methods/observations.qmd
@@ -41,7 +41,7 @@ contributors:
 ---
 
 
-![Observation conducted by the qualitative research team in IPA Colombia (credit: Nicol Lesmes](../../assets/images/observation-1.jpeg){width=80%}
+![Observation conducted by the qualitative research team in IPA Colombia (credit: Nicol Lesmes](../../assets/images/observation-2.JPG){width=80%}
 
 :::{.callout-tip appearance="simple"}
 


### PR DESCRIPTION
# Pull Request Summary 🚀

## What does this PR do? 📝

Fixes a broken image link in the qualitative methods observations page.

## Why is this change needed? 🤔

The image was not rendering on the observations page due to an incorrect link path.

## How was this implemented? 🛠️

Updated the image path in `data-collection/qualitative-methods/observations.qmd`.

## How to test or reproduce? 🧪

1. Navigate to the qualitative methods observations page on the site.
2. Confirm the image renders correctly.

## Screenshots (if applicable) 📷

<!-- Add relevant screenshots or GIFs to illustrate the changes -->

## Checklist ✅

- [x] I have run and tested my changes locally
- [x] I have limited this PR to less than 1000 lines of code change (if not, explain why)
- [ ] I have run linting and formatting on any code changes (if applicable)
- [x] I have updated the documentation (README, etc.) accordingly
- [x] I have reviewed and resolved any merge conflicts
- [x] I have reviewed and resolved any Vale errors
