### PR TITLE
Add Claude AI getting-started guides under Software Guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,6 @@ rsconnect/
 
 /.luarc.json
 .claude/settings.local.json
+
+# Local clone of the IPA Colombia Claude guide (adaptation source material, never committed)
+/source-docs/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -11,6 +11,7 @@ project:
     - "!AGENTS.md"
     - "!docs/"
     - "!extensions/"
+    - "!source-docs/"
 website:
   title: "Research and Data Science Hub"
   favicon: "assets/logos/ipa-favicon.ico"
@@ -104,6 +105,8 @@ website:
             href: ./software/python/index.qmd
           - text: "Quarto"
             href: ./software/quarto/index.qmd
+          - text: "Claude AI"
+            href: ./software/claude/index.qmd
       - text: "Contributing"
         href: ./CONTRIBUTING.qmd
   sidebar:
@@ -415,6 +418,16 @@ website:
                 href: ./software/quarto/index.qmd
               - text: "Writing in Quarto"
                 href: ./software/quarto/basics.qmd
+          - section: "Claude AI"
+            contents:
+              - text: "Getting Started with Claude AI"
+                href: ./software/claude/index.qmd
+              - text: "Installing Claude Code"
+                href: ./software/claude/install.qmd
+              - text: "Claude in the Terminal and VS Code"
+                href: ./software/claude/claude-terminal-vscode.qmd
+              - text: "Claude for Project Managers"
+                href: ./software/claude/claude-desktop-setup.qmd
       - section: "Teams"
         contents:
           - text: "Research and Data Science"

--- a/data-collection/qualitative-methods/ai-assisted-coding.qmd
+++ b/data-collection/qualitative-methods/ai-assisted-coding.qmd
@@ -139,3 +139,7 @@ AI-assisted coding outputs require researcher validation before use in analysis:
 - When model comparison shows low agreement between two LLMs, this typically indicates that theme definitions are too vague. Refine the definitions and re-run rather than assuming the tool has failed.
 - For behavioral cue coding, compute inter-rater reliability such as Cohen's kappa between the AI output and a human coder before relying on the results.
 - Document all analytic choices, including model versions, prompts, and similarity thresholds, for transparency in your research outputs.
+
+## Related resources
+
+- [Getting Started with Claude AI](../../software/claude/index.qmd) covers setting up Claude Code for data analysts and project managers.

--- a/software/claude/claude-desktop-setup.qmd
+++ b/software/claude/claude-desktop-setup.qmd
@@ -230,7 +230,7 @@ Claude saves it to its memory, and the next time you ask for something similar i
 Add this rule to the workspace CLAUDE.md.
 ```
 
-This loop is the most important habit in this whole tutorial: corrections that get saved stop repeating. You can review or edit everything Claude has remembered at any time; it is all plain text files.
+This loop is the most important habit in this whole tutorial: corrections that get saved stop repeating. You can review or edit everything Claude has remembered at any time; it is all plain text files stored in a hidden `.claude/` folder inside your workspace folder.
 
 ## Troubleshooting
 

--- a/software/claude/claude-desktop-setup.qmd
+++ b/software/claude/claude-desktop-setup.qmd
@@ -1,0 +1,245 @@
+---
+title: "Getting Started with Claude for Project Managers"
+abstract: |
+  A step-by-step tutorial for project managers and other non-technical staff to set up a personal workspace in the Claude desktop application. You will create a workspace folder, set up a workspace CLAUDE.md and a personal global CLAUDE.md through a guided interview, and complete your first real task.
+keywords:
+  - "AI"
+  - "Claude"
+  - "project management"
+  - "productivity"
+  - "tutorial"
+license:
+  text: "CC BY-SA"
+  url: https://creativecommons.org/licenses/by-sa/4.0/
+authors-ipa:
+  - "[Juan Felipe García Rodríguez](https://poverty-action.org/people/juan-felipe-garcia-rodriguez)"
+  - "[Diego Quintero Mogollón](https://poverty-action.org/people/diego-quintero-mogollon)"
+contributors:
+  - "[Daniel Martinez](https://poverty-action.org/people/daniel-enriquez)"
+---
+
+:::{.callout-note collapse="true" title="Recognition and Attribution"}
+
+This page is adapted and translated from the [Claude Code guide for IPA Colombia](https://github.com/juanfegarIPA/claude-code-ipa-colombia) by Juan Felipe García Rodríguez and Diego Quintero Mogollón (IPA Colombia), based on a workspace that Juan Felipe built and refined over three months of daily use. The original material is licensed under the [MIT License](https://github.com/juanfegarIPA/claude-code-ipa-colombia/blob/main/LICENSE).
+
+**Changes made:** Content has been translated to English, condensed, and generalized for all IPA offices by Innovations for Poverty Action (IPA).
+
+:::
+
+:::{.callout-tip appearance="simple"}
+
+## Key Takeaways
+
+- You do not need to know how to code. The Claude desktop application works like a chat that can also read and create files on your computer.
+- `CLAUDE.md` files give Claude permanent context. The one in your workspace stays focused on the work; personal context lives in a separate global file that applies everywhere.
+- Claude keeps its own memory of your corrections. Telling it "remember this" after a correction is the single practice that makes it more useful the longer you use it.
+
+:::
+
+This tutorial takes you from never having opened Claude Code to finishing your first real task. It takes about 45 minutes.
+
+## Before you start
+
+Complete the shared setup first: [Installing Claude Code](install.qmd), choosing the **Desktop application** option. Come back here once you can open the app and see your account signed in.
+
+## Step 1: Create your workspace folder
+
+Your workspace is the folder where your files for Claude will live. Claude reads it at the start of every session.
+
+1. Open your file explorer.
+2. Create a folder, for example `Documents/Claude`.
+3. Note the full path of the folder. You will select it in Step 3.
+
+::: {.callout-important}
+
+## The workspace is also a boundary
+
+Unlike a code project, where the repository limits what Claude works with, a personal workspace has no built-in edges: you set them. Treat the workspace folder as the limit of what Claude touches. If you want Claude to consult folders outside it, such as synced Box folders, list the exact folders in your `CLAUDE.md` as an allow list; the template in the next step has a section for this. Everything not on the list stays off limits.
+
+:::
+
+## Step 2: Add your CLAUDE.md files
+
+`CLAUDE.md` is a text file Claude reads at the start of every session. There are two of them, with different jobs:
+
+- **The workspace `CLAUDE.md`** lives in your workspace folder and stays focused on the work: what this workspace is for, how it is organized, and which folders Claude may touch. This is the same pattern data analysts use, where every project repository carries its own project-focused `CLAUDE.md`.
+- **Your global `CLAUDE.md`** lives in your user folder and carries personal context that applies everywhere: who you are, how you like messages written, and your safety rules. Claude reads it in every session, in every folder.
+
+Keep them separate. If something would be true in any folder you work in, it belongs in the global file, not the workspace one.
+
+First, create a file named exactly `CLAUDE.md` in your workspace folder and paste this template into it. Do not fill in the blanks yourself; Claude will interview you in Step 4.
+
+```markdown
+# [Workspace name]
+
+> This file is the briefing Claude reads at the start of every session in
+> this folder. It stays focused on this workspace: what the work is, how
+> it is organized, and what the rules are here. The markers that start
+> with INIT are questions Claude will ask me the first time I open this
+> workspace; once answered, Claude replaces them with my answers and
+> deletes the marker.
+
+## What this workspace is
+
+<!-- INIT-PURPOSE: Ask me what work happens in this workspace and write a
+short description: the area of work, the main deliverables, and who I
+collaborate with on them. -->
+
+## Folders Claude may access
+
+Before reading or searching anywhere, check this allow list. This
+workspace folder is always allowed. Outside it, ONLY the folders listed
+here are allowed; everything else is off limits, even if I link or
+mention it in passing. Ask me before adding a folder to this list.
+
+- [example: C:/Users/me/Box/MyTeam_SharedResources/ — team reference documents]
+
+## Workspace structure
+
+<!-- INIT-STRUCTURE: Ask me whether I prefer to organize this folder by
+project, by type of deliverable, or by area of work. Create the folders
+and update this section accordingly. -->
+
+## Conventions
+
+- One active file per deliverable. Old versions go to archive/ with a
+  descriptive name.
+- Filenames in kebab-case (for example budget-2026.md).
+- Dates in YYYY-MM-DD format so files sort correctly.
+
+## Active projects
+
+[One line per project: name + what it is + where it lives in this
+workspace.]
+
+## Things Claude should know
+
+[Notes about this workspace's work: key contacts, project context,
+recent decisions. Starts empty and grows with use.]
+```
+
+Then create your global `CLAUDE.md` in the `.claude` folder inside your user folder: `C:/Users/YOUR_USER/.claude/CLAUDE.md` on Windows, or `~/.claude/CLAUDE.md` on Mac. Create the `.claude` folder if it does not exist. Paste this template:
+
+```markdown
+# About me
+
+- **Name**: [Your name]
+- **Role**: [Your job title], [your organization]
+- **Time zone**: [Your time zone]
+- **Working language**: [Your language(s)]
+
+## Style
+
+<!-- INIT-VOICE: Ask me how I want drafted messages to sound, and whether
+I want to build a personal voice profile from examples over time. Replace
+this block with my answer. -->
+
+- No emojis unless I ask for them.
+- No generic filler phrases.
+
+## Safety rules
+
+These rules are mandatory everywhere, in every folder and every session.
+They follow my organization's AI policy (at IPA: the AI Usage Guidelines).
+
+- Never include data about research participants (names, locations,
+  identifying details) in prompts or in files.
+- Never include performance evaluations or other sensitive personnel
+  information.
+- Never store passwords or credentials in files.
+- When unsure whether something is confidential, stop and check the
+  policy or ask (at IPA: support@poverty-action.org).
+```
+
+::: {.callout-warning}
+
+Check that both filenames are exactly `CLAUDE.md`. Claude does not read a file saved as `CLAUDE.md.txt`. If you cannot create the `.claude` folder yourself, skip it for now and ask Claude to create the global file for you during the interview in Step 4.
+
+:::
+
+## Step 3: Open Claude Code in your workspace
+
+The desktop app has three tabs: **Chat**, **Cowork**, and **Code**. This tutorial uses the Code tab, where Claude works in a folder you choose and you review each change as it happens.
+
+1. Open the Claude desktop application and select the **Code** tab.
+2. Choose **Local**, then select your workspace folder.
+3. The app shows the contents of the folder. You should see `CLAUDE.md` listed.
+
+::: {.callout-note}
+
+## What about Cowork?
+
+Cowork is Claude's mode for delegating self-contained tasks: you describe the outcome and it delivers finished work, such as a formatted spreadsheet or a briefing document. It suits a different workflow than this tutorial: each Cowork task runs in its own session, without the persistent workspace context that `CLAUDE.md` and Claude's accumulated memory provide here. See [Anthropic's Cowork page](https://claude.com/product/cowork).
+
+:::
+
+## Step 4: Personalize your CLAUDE.md files with the initial interview
+
+The templates you pasted have markers like `<!-- INIT-VOICE -->`. These are questions Claude will ask you to adapt the files to how you work. Send this message:
+
+```text
+I set up my workspace CLAUDE.md and my global CLAUDE.md from templates.
+Read both and interview me to fill in the sections marked with INIT and
+the bracketed fields. Put answers about this workspace's work in the
+workspace file and answers about me personally in the global file. Delete
+each marker once I have answered it.
+```
+
+Claude reads the files, asks you a short series of questions, and fills in your answers in the right file. If you are not sure about an answer, say so and Claude will leave it for later. This takes five to ten minutes.
+
+## Step 5: Do a first real task
+
+Pick a real task from your week. Examples that work well for a first task:
+
+```text
+I took these notes in my meeting with a partner organization: [paste your
+notes]. Write a one-page executive summary.
+```
+
+```text
+Read the budget spreadsheet at [file path] and tell me the three items
+that need attention this week.
+```
+
+```text
+There are 12 files in this project folder: [folder path]. Give me a map
+of what each one contains.
+```
+
+If the first response is not what you wanted, tell Claude what to change. That is the normal way to work, not a failure.
+
+::: {.callout-important}
+
+## Claude prepares decisions; it does not make them
+
+Use Claude to gather inputs, draft options, and surface tradeoffs. The decision itself, and the responsibility for it, always stays with you. Never act on a recommendation you have not reviewed and made your own.
+
+:::
+
+## Step 6: Teach Claude your corrections
+
+Claude Code keeps its own memory per workspace and reads it at the start of every session. When it finishes adjusting something after your correction, send:
+
+```text
+Remember this correction for next time.
+```
+
+Claude saves it to its memory, and the next time you ask for something similar it applies what it learned. For a rule that must always hold, ask instead:
+
+```text
+Add this rule to the workspace CLAUDE.md.
+```
+
+This loop is the most important habit in this whole tutorial: corrections that get saved stop repeating. You can review or edit everything Claude has remembered at any time; it is all plain text files.
+
+## Troubleshooting
+
+| Problem | Solution |
+| --- | --- |
+| The app does not open, asks for Git, or cannot sign in | See the [installation troubleshooting](install.qmd#troubleshooting). |
+| Claude does not read CLAUDE.md | Check that the filename is exactly `CLAUDE.md` and that you selected the workspace folder in the app. |
+| Anything else | Check the [official documentation](https://code.claude.com/docs/). IPA staff can write to [support@poverty-action.org](mailto:support@poverty-action.org). |
+
+## Next steps
+
+Make sure you know your organization's AI policy; it defines what data you may and may not use with Claude. For IPA staff, that policy is the [IPA AI Usage Guidelines](https://ipastorage.box.com/s/mvr67ygvz1y3v8qmgjey67lk7msmyeks). Then keep working through real tasks: the workspace becomes more useful as your `CLAUDE.md` files and Claude's memory accumulate context.

--- a/software/claude/claude-terminal-vscode.qmd
+++ b/software/claude/claude-terminal-vscode.qmd
@@ -1,0 +1,107 @@
+---
+title: "Claude in the Terminal and VS Code"
+abstract: |
+  How to work with Claude in the terminal and VS Code for data analysis. Covers the VS Code extension, setting up a standard research project structure, and starting your first conversation.
+keywords:
+  - "AI"
+  - "Claude Code"
+  - "Stata"
+  - "VS Code"
+  - "installation"
+  - "how-to guide"
+license:
+  text: "CC BY-SA"
+  url: https://creativecommons.org/licenses/by-sa/4.0/
+authors-ipa:
+  - "[Juan Felipe García Rodríguez](https://poverty-action.org/people/juan-felipe-garcia-rodriguez)"
+  - "[Diego Quintero Mogollón](https://poverty-action.org/people/diego-quintero-mogollon)"
+contributors:
+  - "[Daniel Martinez](https://poverty-action.org/people/daniel-enriquez)"
+---
+
+:::{.callout-note collapse="true" title="Recognition and Attribution"}
+
+This page is adapted and translated from the [Claude Code guide for IPA Colombia](https://github.com/juanfegarIPA/claude-code-ipa-colombia) by Juan Felipe García Rodríguez and Diego Quintero Mogollón (IPA Colombia). The original material is licensed under the [MIT License](https://github.com/juanfegarIPA/claude-code-ipa-colombia/blob/main/LICENSE).
+
+**Changes made:** Content has been translated to English, condensed, and updated by Innovations for Poverty Action (IPA). Installation instructions follow the current [official Claude Code documentation](https://code.claude.com/docs/), which differs from the original guide.
+
+:::
+
+:::{.callout-tip appearance="simple"}
+
+## Key Takeaways
+
+- The terminal inside VS Code is where Claude Code integrates with Git, Stata, and your project's commands and logs.
+- Start every project from [`PovertyAction/ipa-stata-template`](https://github.com/PovertyAction/ipa-stata-template) or add a `CLAUDE.md` file to your existing repository.
+- Claude Code reads your project's `CLAUDE.md` at the start of every session, so it works the way your project works.
+
+:::
+
+The terminal inside VS Code is where Claude Code earns its place in analysis work: it runs your project's pipeline commands, reads your repository's conventions from `CLAUDE.md`, edits do-files and scripts beside your own editor, and shows you logs as they are produced. The repository is also a natural boundary: Claude works within the project folder, and the editor gives it unambiguous file paths. This page sets that up.
+
+## Before you start
+
+Complete the shared setup first: [Installing Claude Code](install.qmd), choosing the **Terminal (CLI)** option. This guide also assumes you have [VS Code](../vscode/index.qmd) installed.
+
+## Step 1: Add the VS Code extension
+
+Open VS Code, go to the Extensions view, and install **Claude Code** (published by Anthropic). The extension lets you open Claude Code in a panel beside your files and shows its proposed edits inline.
+
+If your project is based on `ipa-stata-template`, VS Code reads the `.vscode/extensions.json` file in the repository and offers to install the full recommended extension set, including the Stata extension, in one click.
+
+## Step 2: Set up your project
+
+IPA projects follow a standard structure, defined in the open source template [`PovertyAction/ipa-stata-template`](https://github.com/PovertyAction/ipa-stata-template). Anyone can use it. To start a project from it, open the repository on GitHub and select **Use this template**.
+
+```text
+my-project/
+├── do_files/           # Stata scripts
+├── data/
+│   ├── raw/            # Raw data (never edit, never commit)
+│   └── clean/          # Clean data (generated)
+├── outputs/            # Generated tables and figures
+├── logs/               # Execution logs
+├── .vscode/            # Recommended VS Code extensions
+├── .claude/            # Claude Code skills and settings
+├── CLAUDE.md           # Project briefing for Claude Code
+├── .env                # Local Stata path (not committed to Git)
+└── .here               # Project root marker
+```
+
+The `CLAUDE.md` file is the project briefing that Claude Code reads at the start of every session: what the project is, how it is organized, and which rules to follow. The template ships with one ready to adapt. If you already have a project repository, you do not need to start over; add a `CLAUDE.md` that describes your existing structure.
+
+Keep the project `CLAUDE.md` focused on the project: it travels with the repository, and everyone who works on it reads the same briefing. Personal preferences that apply across all your projects belong in your global `CLAUDE.md` at `~/.claude/CLAUDE.md`, which Claude also reads in every session.
+
+::: {.callout-warning}
+
+## Keep raw data away from Claude
+
+Raw survey data usually contains personally identifiable information, which is Confidential under IPA policy. Do not ask Claude to read files in `data/raw/`, and do not paste individual-level data into prompts. Claude can still write and fix the code that processes that data, because it works from your code and logs, not from the data itself.
+
+:::
+
+## Step 3: Start your first conversation
+
+From the VS Code terminal, go to the root of your project and start Claude Code:
+
+```bash
+cd path/to/your/project
+claude
+```
+
+Claude Code reads your `CLAUDE.md` automatically. To verify, ask:
+
+```text
+What project is this?
+```
+
+If Claude describes your project correctly, everything works.
+
+## Troubleshooting
+
+| Problem | Solution |
+| --- | --- |
+| `claude` does not start | See the [installation troubleshooting](install.qmd#troubleshooting). |
+| Claude does not recognize the project | Check that you are in the project root with `pwd`. Claude Code looks for `CLAUDE.md` in the current directory. |
+| The Stata extension does not run do-files | Check that your `.env` file points to your Stata executable. The template includes a `.env-example` to copy. |
+| Anything else | Run `claude doctor` or check the [official documentation](https://code.claude.com/docs/). IPA staff can write to [support@poverty-action.org](mailto:support@poverty-action.org). |

--- a/software/claude/index.qmd
+++ b/software/claude/index.qmd
@@ -1,0 +1,126 @@
+---
+title: "Getting Started with Claude AI"
+abstract: |
+  An orientation to Claude, an AI assistant developed by Anthropic, and Claude Code, the version of Claude that works directly with the files on your computer. This page explains what these tools can and cannot do, how access works at IPA, and how to choose between the setup path for data analysts and the setup path for project managers.
+keywords:
+  - "AI"
+  - "Claude"
+  - "Claude Code"
+  - "large language models"
+  - "productivity"
+  - "explanation"
+license:
+  text: "CC BY-SA"
+  url: https://creativecommons.org/licenses/by-sa/4.0/
+authors-ipa:
+  - "[Juan Felipe García Rodríguez](https://poverty-action.org/people/juan-felipe-garcia-rodriguez)"
+  - "[Diego Quintero Mogollón](https://poverty-action.org/people/diego-quintero-mogollon)"
+contributors:
+  - "[Daniel Martinez](https://poverty-action.org/people/daniel-enriquez)"
+---
+
+:::{.callout-note collapse="true" title="Recognition and Attribution"}
+
+This page is adapted and translated from the [Claude Code guide for IPA Colombia](https://github.com/juanfegarIPA/claude-code-ipa-colombia) by Juan Felipe García Rodríguez and Diego Quintero Mogollón (IPA Colombia). The original material is licensed under the [MIT License](https://github.com/juanfegarIPA/claude-code-ipa-colombia/blob/main/LICENSE).
+
+**Changes made:** Content has been translated to English, condensed, and updated by Innovations for Poverty Action (IPA) to align with current Anthropic documentation and the conventions of this site.
+
+:::
+
+:::{.callout-tip appearance="simple"}
+
+## Key Takeaways
+
+- Claude is an AI assistant developed by Anthropic. Claude Code extends it to read and edit files on your computer, generate documents, and remember your working context between sessions.
+- IPA staff have access to Claude, including Claude Code, through the organization's Enterprise license.
+- Never share confidential data, including personally identifiable information about research participants, with AI tools. At IPA, the [IPA AI Usage Guidelines](https://ipastorage.box.com/s/mvr67ygvz1y3v8qmgjey67lk7msmyeks) define what is allowed.
+- Two setup paths are available: one for data analysts working with code, and one for project managers and other staff who do not code.
+
+:::
+
+## Overview
+
+Claude is an AI assistant developed by [Anthropic](https://www.anthropic.com). Like other large language model assistants, it can draft and revise text, explain and write code, summarize documents, and answer questions. It comes in three forms:
+
+- **Chats**: the conversation interface at [claude.ai](https://claude.ai) and in the desktop app. No access to your files.
+- **Cowork**: a mode that completes multi-step knowledge work on your behalf, such as research synthesis and document preparation, and delivers finished work. See [Anthropic's Cowork page](https://claude.com/product/cowork).
+- **Claude Code**: an interactive assistant that works directly with the files on your computer, where you review each change as it happens.
+
+These guides focus on **Claude Code**. The two modes suit different workflows: Claude Code works inside a workspace or repository whose files carry persistent context between sessions, while Cowork runs each task in its own session without that context. Use Cowork for self-contained deliverables; use Claude Code for the ongoing, context-heavy work these guides cover.
+
+Using Claude requires a paid plan or an organizational license. At IPA, staff have access through the organization's Enterprise license, which covers both the chat interface and Claude Code. If you work at another organization, check what coverage and AI policy apply to you; the guidance on these pages still works the same way.
+
+This guide helps you set up Claude Code for research and operations work. It adapts material that IPA Colombia developed and tested over several months of real use, and it serves two audiences:
+
+- **Data analysts** who write code, manage Stata or Python projects, and work in version-controlled repositories.
+- **Project managers and other staff** who work with documents, spreadsheets, presentations, and email, and who do not need to write code.
+
+## What is Claude Code?
+
+Claude Code is a way to converse with Claude directly from your computer. It is available in the Claude desktop app (the **Code** tab), as a command line tool, and in a web version. Unlike Chats, Claude Code can:
+
+- **Read and edit files** on your computer, such as documents, spreadsheets, and folders.
+- **Generate documents** in formats like Word, PowerPoint, and Excel that are ready to share.
+- **Automate repetitive tasks** such as reports, follow-ups, and formatting.
+- **Remember who you are and how you work** between sessions, through `CLAUDE.md` context files and a memory of its own that it builds as you work together.
+
+::: {.callout-tip}
+
+## Do you need to know how to code?
+
+No. The desktop application has a visual interface where you converse with Claude as you would in a chat. The difference is that Claude can access your local files and produce documents. If you have used Claude or another AI chat in the browser, Claude Code is the next step.
+
+:::
+
+::: {.callout-important}
+
+## What Claude is not
+
+Claude does not replace your judgment, and it should never make decisions for you. It can gather inputs, draft options, and flag tradeoffs, but the decision and the responsibility for it stay with you. It is also not file storage and not a search engine. Always review what it produces before you use or share it.
+
+:::
+
+## Use AI safely with research data
+
+Research organizations handle data whose disclosure can harm study participants, staff, and partners. Before you use any AI tool for work, know your organization's AI policy and your data's classification.
+
+At IPA, the [IPA AI Usage Guidelines](https://ipastorage.box.com/s/mvr67ygvz1y3v8qmgjey67lk7msmyeks) set the rules. The core rule: IPA's use of Claude is approved for **Public** and **Internal** data only. Do not share **Confidential** or **Highly Confidential** data, which includes any personally identifiable information about research participants, staff, or partners.
+
+For guidance on AI and qualitative research data, see [AI-Assisted Qualitative Coding](../../data-collection/qualitative-methods/ai-assisted-coding.qmd). IPA staff who are unsure about a data classification can contact [support@poverty-action.org](mailto:support@poverty-action.org).
+
+## Choose your path
+
+Everyone starts with the same setup: [Installing Claude Code](install.qmd) covers checking your access, installing Git, and installing the app or the command line tool.
+
+After that, the main question is where you are comfortable working:
+
+::: {.callout-tip appearance="simple"}
+
+## In the terminal and VS Code
+
+For anyone comfortable in a terminal or editor; most data analysts work here. Claude integrates with Git, Stata, and IPA's standard project structure.
+
+- [Claude in the Terminal and VS Code](claude-terminal-vscode.qmd)
+
+:::
+
+::: {.callout-tip appearance="simple"}
+
+## In the Claude desktop app
+
+For anyone who prefers an app with a visual interface; most project managers work here. A personal workspace folder, no coding required.
+
+- [Getting Started with Claude for Project Managers](claude-desktop-setup.qmd)
+
+:::
+
+## Resources and support
+
+- [Claude Code documentation](https://code.claude.com/docs/) provides the official Anthropic reference.
+- [`PovertyAction/ipa-stata-template`](https://github.com/PovertyAction/ipa-stata-template) is IPA's open source Stata project template, designed to work well with Claude Code.
+- [IPA AI Usage Guidelines](https://ipastorage.box.com/s/mvr67ygvz1y3v8qmgjey67lk7msmyeks) set the institutional policy for IPA staff. Reading them is required before using AI tools for IPA work.
+
+IPA staff can get support through these channels:
+
+- Technical questions about Claude Code: [support@poverty-action.org](mailto:support@poverty-action.org).
+- Questions about confidential data, Azure OpenAI, or local LLMs: [researchsupport@poverty-action.org](mailto:researchsupport@poverty-action.org).

--- a/software/claude/install.qmd
+++ b/software/claude/install.qmd
@@ -1,0 +1,118 @@
+---
+title: "Installing Claude Code"
+abstract: |
+  The setup steps shared by every Claude Code user: checking your access, installing Git, and installing either the desktop application or the command line tool. Complete this page first, then continue with the guide for your role.
+keywords:
+  - "AI"
+  - "Claude Code"
+  - "installation"
+  - "how-to guide"
+license:
+  text: "CC BY-SA"
+  url: https://creativecommons.org/licenses/by-sa/4.0/
+authors-ipa:
+  - "[Juan Felipe García Rodríguez](https://poverty-action.org/people/juan-felipe-garcia-rodriguez)"
+  - "[Diego Quintero Mogollón](https://poverty-action.org/people/diego-quintero-mogollon)"
+contributors:
+  - "[Daniel Martinez](https://poverty-action.org/people/daniel-enriquez)"
+---
+
+:::{.callout-note collapse="true" title="Recognition and Attribution"}
+
+This page is adapted and translated from the [Claude Code guide for IPA Colombia](https://github.com/juanfegarIPA/claude-code-ipa-colombia) by Juan Felipe García Rodríguez and Diego Quintero Mogollón (IPA Colombia). The original material is licensed under the [MIT License](https://github.com/juanfegarIPA/claude-code-ipa-colombia/blob/main/LICENSE).
+
+**Changes made:** Content has been translated to English, condensed, and updated by Innovations for Poverty Action (IPA). Installation instructions follow the current [official Claude Code documentation](https://code.claude.com/docs/), which differs from the original guide.
+
+:::
+
+These steps are the same for everyone. Complete them once, then continue based on where you are comfortable working: in [the terminal and VS Code](claude-terminal-vscode.qmd), or in [the Claude desktop app](claude-desktop-setup.qmd).
+
+## Step 1: Check your access
+
+Claude Code requires a paid Claude plan, such as Pro, Max, Team, or Enterprise. The free claude.ai plan does not include it.
+
+At IPA, staff are covered by the organization's Enterprise license:
+
+1. Go to [claude.ai](https://claude.ai) and sign in with your IPA email.
+2. If you see the IPA logo or an "Enterprise" label, you are covered.
+3. If not, contact [support@poverty-action.org](mailto:support@poverty-action.org) to request a seat.
+
+::: {.callout-note}
+
+## Why an organizational license matters
+
+An enterprise contract typically includes a data processing agreement and retention policies that protect the organization's information. IPA's Enterprise contract with Anthropic does this for IPA. Personal accounts and personal API keys work technically, but they fall outside institutional coverage. Use the seat your organization provides.
+
+:::
+
+## Step 2: Install Git
+
+Claude Code uses Git to run commands behind the scenes, so install it even if you never use it yourself. You do not need a GitHub account.
+
+::: {.panel-tabset group="OS"}
+
+## Windows
+
+Download the installer from [git-scm.com](https://git-scm.com/downloads/win), run it, and accept all the default options.
+
+## Mac
+
+Open the Terminal app and run `git --version`. If Git is missing, macOS offers to install it; accept the prompt.
+
+:::
+
+## Step 3: Install Claude Code
+
+The main question is where you are comfortable working: a terminal inside VS Code, or an app with a visual interface. Both forms are covered by the same license, do the same work, and can be installed side by side.
+
+::: {.panel-tabset}
+
+## Desktop application
+
+If you prefer an app with a visual interface. Most project managers start here.
+
+1. Download the app from [claude.ai/download](https://claude.ai/download), available for Windows and Mac.
+2. Install it with the default options.
+3. Open it and sign in with the same account you checked in Step 1.
+
+## Terminal (CLI)
+
+If you are comfortable in a terminal or VS Code. Most data analysts start here. Install with the native installer, which keeps itself up to date automatically.
+
+On Windows, open PowerShell and run:
+
+```bash
+irm https://claude.ai/install.ps1 | iex
+```
+
+On Mac or Linux, open a terminal and run:
+
+```bash
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+Verify the installation by opening a new terminal and running:
+
+```bash
+claude --version
+```
+
+The first time you run `claude`, it asks you to authenticate. Sign in with the same account you checked in Step 1. You do not need an API key. For a more detailed check of your setup, run `claude doctor`.
+
+:::
+
+## Troubleshooting
+
+| Problem | Solution |
+| --- | --- |
+| `claude: command not found` | Close and reopen the terminal. If it persists, run the installer again. |
+| Authentication error | Check that you are signing in with the right account and that your plan or seat is active. |
+| The app asks for Git, or cannot run commands | Install Git; see Step 2. |
+| Anything else | Run `claude doctor` in the terminal or check the [official documentation](https://code.claude.com/docs/). IPA staff can write to [support@poverty-action.org](mailto:support@poverty-action.org). |
+
+## Next steps
+
+Continue with the guide for the form you installed:
+
+- Terminal and VS Code: [Claude in the Terminal and VS Code](claude-terminal-vscode.qmd)
+- Desktop app: [Getting Started with Claude for Project Managers](claude-desktop-setup.qmd)

--- a/software/index.qmd
+++ b/software/index.qmd
@@ -63,3 +63,13 @@ Code editors and integrated development environments provide tools for writing, 
 These tools form the core of data analysis and research workflows at IPA. Stata is widely used for econometric analysis and data cleaning. Python provides powerful libraries for data science, machine learning, and automation. Quarto enables creation of reproducible research documents combining code, analysis, and narrative.
 
 :::
+
+::: {.callout-tip appearance="simple"}
+
+## AI Assistants
+
+- [Claude AI](claude/index.qmd)
+
+Claude is an AI assistant developed by Anthropic that can read and edit local files, generate documents, and support analysis workflows. These guides cover setting up Claude Code for data analysts and for project managers, with the safeguards research data requires. IPA staff have access through the organization's Enterprise license.
+
+:::


### PR DESCRIPTION
## What this PR is

An **initial test slice** of a larger effort: bringing the [Claude Code guide for IPA Colombia](https://github.com/juanfegarIPA/claude-code-ipa-colombia) (MIT) by Juan Felipe Garcia Rodriguez and Diego Quintero Mogollon into the Hub. There is more of their material still to adapt (AI safety, prompting, Stata workflow, manager templates and recipes are queued as follow-up PRs). Before adapting the rest, we need an **initial revision of these four pages to confirm they comply with the Hub's layout, style, and Diataxis conventions** - so later PRs can follow a validated pattern instead of repeating mistakes at scale.

## What reviewers should check

- Layout and structure: navbar/sidebar placement under Software Guides, page anatomy (frontmatter, Key Takeaways, callouts, tabsets, troubleshooting tables) against existing Hub pages.
- Style and voice: plain accessible English, dual audience (the Hub is public as well as internal - tool-neutral guidance first, "at IPA" scoping for org specifics, following the vscode/quarto/stata precedent).
- Diataxis fit: index = explanation/router, install + terminal/VS Code = how-to, desktop app = tutorial.
- Attribution pattern: authors-ipa credit + MIT recognition callout on every page (pattern from `data-science/data-analysis/variables.qmd`).

## The pages

- `software/claude/index.qmd` - "Getting Started with Claude AI" (explanation/router): what Claude is (Chats / Cowork / Claude Code), what it is not, data-safety rules, and routing to the two setup tracks.
- `software/claude/install.qmd` - "Installing Claude Code" (how-to): shared setup core - access check, Git, and the desktop app or CLI install.
- `software/claude/claude-terminal-vscode.qmd` - "Claude in the Terminal and VS Code" (how-to): VS Code extension, `ipa-stata-template` project structure, first conversation.
- `software/claude/claude-desktop-setup.qmd` - "Getting Started with Claude for Project Managers" (tutorial): workspace folder, workspace + global `CLAUDE.md` with a guided self-interview, first real task, teaching corrections.

Also: navbar/sidebar entries in `_quarto.yml`, an AI Assistants blurb on `software/index.qmd`, a cross-link from the qualitative AI-assisted coding page, and a `.gitignore` entry for the local source clone.

## How the source was adapted

Content was translated to English, condensed, generalized for all offices, and updated against current Anthropic documentation - adapted, not ported:

- The audience split happens at "where are you comfortable working" (terminal/VS Code vs the desktop app), after a shared setup core - not at analyst vs manager up front. Git is required in both tracks.
- Installation follows the current native installer (no Node/npm); the desktop app flow uses the current Code tab; Claude Code's built-in memory replaces the source's manual feedback file; the source's custom JavaScript Box-guardrail hook is replaced by an allow-list section in the workspace `CLAUDE.md` template (instruction-level now; native permission settings planned for a later PR).
- All IPA Colombia project-specific material (study results, partner references, internal paths, staff names) was stripped for the public site.

## Open question for review (Kelly)

Placement is provisional. This sits under **Software Guides** because it is mainly about bootstrapping Claude as a tool. As the LLM/agent content above lands, should this remain a software guide, or should we plan a dedicated top-level AI/LLM section? The directory is flat (`software/claude/`) so relocation is cheap either way.

## Validation

- `just vale-file` on all four pages: 0 errors (one intentional warning).
- `just fmt-md` / markdownlint: clean.
- Full `quarto render`: 141 files, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
